### PR TITLE
Remove the "Model" section from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,6 @@ The plugin will automatically be added in the `default` and `all` editor profile
 
 Once the plugin is configured in the appropriate editor profiles in `app/config/editor-profiles.js` it will be automatically be picked up by the rdfa-editor.
 
-### Models
-On installation the plugin will generate a `artikel` and `besluit` model. In case the host application already contains one of these models, the plugin's model can be merged in the existing model using the `<name>-model` mixin.
-
-E.g.
-```javascript
-import Model from 'ember-data/model';
-import BesluitModelMixin from '@lblod/ember-rdfa-editor-citaten-plugin/mixins/besluit-model';
-
-export default Model.extend(BesluitModelMixin, {
-  // your template model here
-});
-```
-
 Contributing
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
The models are no longer part of this addon.