### PR TITLE
Specify concurrency as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ package-lock.json
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# editors
+.idea

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
     "ember-cli-update": "^0.34.10",
+    "ember-concurrency": "^2.1.2",
+    "ember-concurrency-decorators": "^2.0.3",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
   },
+  "peerDependencies": {
+    "ember-concurrency": "^1.0.0 || ^2.0.0-rc.1",
+    "ember-concurrency-decorators": "^2.0.3"
+  },
   "dependencies": {
     "ember-cli-babel": "^7.21.0",
     "ember-cli-htmlbars": "^5.2.0",
@@ -47,8 +51,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
     "ember-cli-update": "^0.34.10",
-    "ember-concurrency": "^2.1.2",
-    "ember-concurrency-decorators": "^2.0.3",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",


### PR DESCRIPTION
Ember-concurrency was being used without specifying it as a dependency in package.json