### PR TITLE
Explicit import of the debug component

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "peerDependencies": {
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.6"
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.9"
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.10",
@@ -39,8 +39,7 @@
     "ember-intl": "^5.7.2"
   },
   "devDependencies": {
-    "@appuniversum/appuniversum": "^0.3.1",
-    "@appuniversum/ember-appuniversum": "^0.9.2",
+    "@appuniversum/ember-appuniversum": "^0.11.0",
     "@codemirror/basic-setup": "^0.19.1",
     "@codemirror/lang-html": "^0.19.4",
     "@codemirror/lang-xml": "^0.19.1",
@@ -49,7 +48,7 @@
     "@embroider/test-setup": "^0.48.1",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.6",
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.9",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.0.2",

--- a/tests/dummy/app/components/rdfa-editor-with-debug.js
+++ b/tests/dummy/app/components/rdfa-editor-with-debug.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug';

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -45,27 +45,27 @@
   > p > a {
     transition: color .3s ease-in-out, text-decoration 3s ease-in-out;
     font-weight: 500;
-    text-decoration-color: $say-primary-300;
+    text-decoration-color: var(--au-blue-300);
   }
 
   > a,
   > p > a,
   > a:visited,
   > p > a:visited {
-    color: $say-primary-700;
+    color: var(--au-blue-700);
   }
 
   > a:hover,
   > p > a:hover,
   > a:focus,
   > p > a:focus {
-    color: $say-primary-700;
-    text-decoration-color: $say-primary-300;
+    color: var(--au-blue-700);
+    text-decoration-color: var(--au-blue-300);
   }
 
   > a:focus,
   > p > a:focus {
-    outline: .2rem dashed $say-primary-300;
+    outline: .2rem dashed var(--au-blue-300);
     outline-offset: .2rem;
   }
 
@@ -80,7 +80,7 @@
   position: relative;
   z-index: 1;
   padding: 2rem;
-  box-shadow: 0 1px 3px rgba($say-primary-900, .1), 0 4px 20px rgba($say-primary-900, .035), 0 1px 1px rgba($say-primary-900, .025);
+  box-shadow: 0 1px 3px rgba(var(--au-blue-900), .1), 0 4px 20px rgba(var(--au-blue-900), .035), 0 1px 1px rgba(var(--au-blue-900), .025);
 }
 
 // Fix scroll

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{page-title "rdfa-editor-citaten-plugin"}}
 
-<Rdfa::RdfaEditorWithDebug
+<RdfaEditorWithDebug
   @rdfaEditorInit={{this.rdfaEditorInit}}
   @plugins={{this.plugins}}
   @editorOptions={{hash
@@ -19,4 +19,4 @@
     showIndentButtons="true"
   }}>
   <h1>Dummy app - rdfa-editor-citaten-plugin</h1>
-</Rdfa::RdfaEditorWithDebug>
+</RdfaEditorWithDebug>


### PR DESCRIPTION
Due to the export of the debug component in the editor, the consuming app also imports modules only related to the debug component for no reason. The solution was to not export the debug component. The plugins that want to use the debug component need to explicitly import it first. This PR does that. Explicit importing is needed for ember-rdfa-editor v0.50.0-beta.8 and onward, but the explicit import won't break on older editor versions.