### PR TITLE
Added ember-concurrency as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "test:ember-compatibility": "ember try:each"
   },
   "peerDependencies": {
-    "@lblod/ember-rdfa-editor": "^0.50.0-beta.9"
+    "@lblod/ember-rdfa-editor": "^0.50.0-beta.9",
+    "ember-concurrency": "^2.2.0",
+    "ember-concurrency-decorators": "^2.0.3"
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.10",


### PR DESCRIPTION
Some projects (embeddable) need at least a warning to notify that
ember-concurrency is needed, as it is needed by embeddable itself.