### PR TITLE
Adjusted triggering of the Card with search terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,57 @@
 # @lblod/ember-rdfa-editor-citaten-plugin
 
-RDFa editor plugin to insert citations of a legal resource or legal expression level.
+RDFa editor plugin to insert references to a legal resource or legal expression into the document.
 
-Compatibility
-------------------------------------------------------------------------------
+## Compatibility
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
 * Node.js v12 or above
 
+## Installation
 
-Installation
-------------------------------------------------------------------------------
-```
+```bash
 ember install @lblod/ember-rdfa-editor
 ember install @lblod/ember-rdfa-editor-citaten-plugin
 ```
 
+## Configuration
 
-### Using the plugin
+To enable this plugin on the editor, add `citaten-plugin` to the `@plugins` collection. E.g.:
+
+```handlebars
+<RdfaEditorWithDebug
+  @plugins={{array 'citaten-plugin'}}
+  ...
+  >
+  <h1>My app</h1>
+</RdfaEditorWithDebug>
+```
+
+## Using the plugin
 
 This plugin can be triggered by typing one of the following in the correct RDFa context (the `besluit:motivering` inside a `besluit:Besluit`).
 
- * [a-z]+decreet (e.g "gemeentedecreet")
- * decreet [words to search for]
- * omzendbrief [words to search for]
- * verdrag [words to search for]
- * samenwerkingsakkoord [words to search for]
- * wetboek [words to search for]
- * wet [words to search for]
- * koninklijk besluit [words to search for]
- * ministerieel besluit [words to search for]
- * besluit van de vlaamse regering [words to search for]
- * protocol [words to search for]
- * grondwet
- * grondwetswijziging [words to search for]
- * gecoordineerde wetten [words to search for]
+* [specification]**decreet** [words to search for] *(e.g. "gemeentedecreet wijziging")*
+* **omzendbrief** [words to search for]
+* **verdrag** [words to search for]
+* **grondwetswijziging** [words to search for]
+* **samenwerkingsakkoord** [words to search for]
+* [specification]**wetboek** [words to search for]
+* **protocol** [words to search for]
+* **besluit van de vlaamse regering** [words to search for]
+* **gecoordineerde wetten** [words to search for]
+* [specification]**wet** [words to search for] *(e.g. "kieswet wijziging", or "grondwet")*
+* **koninklijk besluit** [words to search for]
+* **ministerieel besluit** [words to search for]
+* **genummerd besluit** [words to search for]
 
-## Configuration
-### Dispatcher configuration
-The plugin will automatically be added in the `default` and `all` editor profiles in `app/config/editor-profiles.js`. Add the plugin name `rdfa-editor-citaten-plugin` to other editor profiles if you want to enable the plugin in these profiles, too.
+You should be able to add a reference manually by clicking on the `Insert` > `Insert reference` item in the Insert menu located on the top right of the editor. This will open the advanced search window. **Note** that this will only be avaliable in the proper context (see above in this section).
 
-Once the plugin is configured in the appropriate editor profiles in `app/config/editor-profiles.js` it will be automatically be picked up by the rdfa-editor.
-
-Contributing
-------------------------------------------------------------------------------
+## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
-
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/addon/components/editor-plugins/citaat-card.js
+++ b/addon/components/editor-plugins/citaat-card.js
@@ -38,7 +38,7 @@ const BASIC_MULTIPLANE_CHARACTER = '\u0021-\uFFFF'; // most of the characters us
 // )
 const NNWS = '[^\\S\\n]';
 const CITATION_REGEX = new RegExp(
-  `((\\w*decreet|omzendbrief|verdrag|grondwetswijziging|samenwerkingsakkoord|\\w*wetboek|protocol|besluit${NNWS}van${NNWS}de${NNWS}vlaamse${NNWS}regering|geco[öo]rdineerdewetten|\\w*wet|koninklijk${NNWS}?besluit|ministerieel${NNWS}?besluit|genummerd${NNWS}?koninklijk${NNWS}?besluit|\\w*${NNWS}?besluit)${NNWS}*((${NNWS}|[${BASIC_MULTIPLANE_CHARACTER};:'"()&-_]){3,})?)`,
+  `((\\w*decreet|omzendbrief|verdrag|grondwetswijziging|samenwerkingsakkoord|\\w*wetboek|protocol|besluit${NNWS}van${NNWS}de${NNWS}vlaamse${NNWS}regering|geco[öo]rdineerde${NNWS}wetten|\\w*wet|koninklijk${NNWS}?besluit|ministerieel${NNWS}?besluit|genummerd${NNWS}?koninklijk${NNWS}?besluit|\\w*${NNWS}?besluit)${NNWS}*((${NNWS}|[${BASIC_MULTIPLANE_CHARACTER};:'"()&-_]){3,})?)`,
   'uig'
 );
 

--- a/addon/components/editor-plugins/citaat-card.js
+++ b/addon/components/editor-plugins/citaat-card.js
@@ -38,7 +38,7 @@ const BASIC_MULTIPLANE_CHARACTER = '\u0021-\uFFFF'; // most of the characters us
 // )
 const NNWS = '[^\\S\\n]';
 const CITATION_REGEX = new RegExp(
-  `((\\w*decreet|omzendbrief|verdrag|grondwetswijziging|samenwerkingsakkoord|\\w*wetboek|protocol|besluit${NNWS}van${NNWS}de${NNWS}vlaamse${NNWS}regering|geco[öo]rdineerdewetten|\\w*wet|koninklijk${NNWS}?besluit|ministerieel${NNWS}?besluit|genummerd${NNWS}?koninklijk${NNWS}?besluit|\\w*${NNWS}?besluit)${NNWS}*((${NNWS}|[${BASIC_MULTIPLANE_CHARACTER};:'"()&\-_]){3,})?)`,
+  `((\\w*decreet|omzendbrief|verdrag|grondwetswijziging|samenwerkingsakkoord|\\w*wetboek|protocol|besluit${NNWS}van${NNWS}de${NNWS}vlaamse${NNWS}regering|geco[öo]rdineerdewetten|\\w*wet|koninklijk${NNWS}?besluit|ministerieel${NNWS}?besluit|genummerd${NNWS}?koninklijk${NNWS}?besluit|\\w*${NNWS}?besluit)${NNWS}*((${NNWS}|[${BASIC_MULTIPLANE_CHARACTER};:'"()&-_]){3,})?)`,
   'uig'
 );
 

--- a/addon/components/editor-plugins/helpers/alert-no-items.hbs
+++ b/addon/components/editor-plugins/helpers/alert-no-items.hbs
@@ -4,7 +4,7 @@
   @alertIcon="cross"
   @alertSize="{{if @fullSize "default" "small"}}"
   @closable={{false}}
-  class="{{unless @fullSize "au-u-margin-top-small"}}"
+  class="{{unless @fullSize "au-u-margin-small"}}"
   ...attributes>
 </AuAlert>
 

--- a/addon/utils/processMatch.js
+++ b/addon/utils/processMatch.js
@@ -1,48 +1,55 @@
 import { LEGISLATION_TYPES } from './legislation-types';
 import { isBlank } from '@ember/utils';
 
-const STOP_WORDS = ['het', 'de', 'van', 'tot'];
+const STOP_WORDS = ['het', 'de', 'van', 'tot', 'dat'];
 const DATE_REGEX = new RegExp('(\\d{1,2})\\s(\\w+)\\s(\\d{2,4})', 'g');
 const INVISIBLE_SPACE = '\u200B';
+const UNBREAKABLE_SPACE = '\u00A0';
+const SPACES_REGEX = new RegExp('[\\s${UNBREAKABLE_SPACE}]+');
 
 export default function processMatch(match) {
-  const quickMatch = match.groups;
-  if (!quickMatch) return false;
-  const input = quickMatch[5] ? quickMatch[5] : quickMatch[3];
-  const cleanedInput = cleanupText(input);
-  const words = cleanedInput
-    .split(/[\s\u00A0]+/)
+  const matchgroups = match.groups;
+  const type = matchgroups[2];
+  const searchTerms = matchgroups[3];
+  let cleanedSearchTerms = cleanupText(searchTerms)
+    .split(SPACES_REGEX)
     .filter(
       (word) => !isBlank(word) && word.length > 3 && !STOP_WORDS.includes(word)
-    );
+    )
+    .join(' ');
 
-  const articleIndex = quickMatch[3].indexOf('artikel');
-  const matchingText =
-    articleIndex >= 0 ? quickMatch[3].slice(0, articleIndex) : quickMatch[3];
   let typeLabel;
-  if (quickMatch[4]) {
-    if (quickMatch[4].toLowerCase().startsWith('gecoordineerde wetten')) {
-      typeLabel = 'gecoördineerde wetten';
-    } else {
-      typeLabel = quickMatch[4].toLowerCase().trim();
-    }
+  if (/\w+decreet/i.test(type)) {
+    typeLabel = 'decreet';
+    cleanedSearchTerms = `${type} ${cleanedSearchTerms}`;
+  } else if (/decreet/i.test(type)) {
+    typeLabel = 'decreet';
+  } else if (/\w+wetboek/i.test(type)) {
+    typeLabel = 'wetboek';
+    cleanedSearchTerms = `${type} ${cleanedSearchTerms}`;
+  } else if (/wetboek/i.test(type)) {
+    typeLabel = 'wetboek';
+  } else if (/gecoordineerde wetten/i.test(type)) {
+    typeLabel = 'gecoördineerde wetten';
+  } else if (/grondwet/i.test(type)) {
+    typeLabel = 'grondwet';
+  } else if (/\w*wet/i.test(type)) {
+    typeLabel = 'wet';
+    cleanedSearchTerms = `${type} ${cleanedSearchTerms}`;
   } else {
-    if (matchingText.includes('grondwet')) {
-      typeLabel = 'grondwet';
-    } else {
-      // default to 'decreet' if no type can be determined
-      typeLabel = 'decreet';
-    }
+    typeLabel = type.toLowerCase().trim();
   }
-  const typeUri = LEGISLATION_TYPES[typeLabel];
+
+  const typeUri = LEGISLATION_TYPES[typeLabel] || LEGISLATION_TYPES['decreet'];
   return {
-    text: words.join(' '),
+    text: cleanedSearchTerms,
     legislationTypeUri: typeUri,
-    range: match.groupRanges[3],
+    range: match.groupRanges[1],
   };
 }
 
 function cleanupText(text) {
+  if (!text) return "";
   const { textWithoutDates } = extractDates(text);
   const textWithoutOddChars = textWithoutDates.replace(
     new RegExp(`[,.:"()&${INVISIBLE_SPACE}]`, 'g'),

--- a/addon/utils/processMatch.js
+++ b/addon/utils/processMatch.js
@@ -33,9 +33,11 @@ export default function processMatch(match) {
     typeLabel = 'gecoördineerde wetten';
   } else if (/grondwet/i.test(type)) {
     typeLabel = 'grondwet';
-  } else if (/\w*wet/i.test(type)) {
+  } else if (/\w+wet/i.test(type)) {
     typeLabel = 'wet';
     cleanedSearchTerms = `${type} ${cleanedSearchTerms}`;
+  } else if (/wet/i.test(type)) {
+    typeLabel = 'wet';
   } else {
     typeLabel = type.toLowerCase().trim();
   }

--- a/addon/utils/processMatch.js
+++ b/addon/utils/processMatch.js
@@ -4,7 +4,6 @@ import { isBlank } from '@ember/utils';
 const STOP_WORDS = ['het', 'de', 'van', 'tot', 'dat'];
 const DATE_REGEX = new RegExp('(\\d{1,2})\\s(\\w+)\\s(\\d{2,4})', 'g');
 const INVISIBLE_SPACE = '\u200B';
-const UNBREAKABLE_SPACE = '\u00A0';
 const SPACES_REGEX = new RegExp('[\\s${UNBREAKABLE_SPACE}]+');
 
 export default function processMatch(match) {
@@ -51,7 +50,7 @@ export default function processMatch(match) {
 }
 
 function cleanupText(text) {
-  if (!text) return "";
+  if (!text) return '';
   const { textWithoutDates } = extractDates(text);
   const textWithoutOddChars = textWithoutDates.replace(
     new RegExp(`[,.:"()&${INVISIBLE_SPACE}]`, 'g'),

--- a/addon/utils/processMatch.js
+++ b/addon/utils/processMatch.js
@@ -28,9 +28,7 @@ export default function processMatch(match) {
     cleanedSearchTerms = `${type} ${cleanedSearchTerms}`;
   } else if (/wetboek/i.test(type)) {
     typeLabel = 'wetboek';
-  } else if (/gecoordineerde wetten/i.test(type)) {
-    typeLabel = 'gecoördineerde wetten';
-  } else if (/gecoördineerde wetten/i.test(type)) {
+  } else if (/geco[oö]rdineerde[^\S\n]wetten/i.test(type)) {
     typeLabel = 'gecoördineerde wetten';
   } else if (/grondwetswijziging/i.test(type)) {
     typeLabel = 'grondwetswijziging';

--- a/addon/utils/processMatch.js
+++ b/addon/utils/processMatch.js
@@ -30,6 +30,10 @@ export default function processMatch(match) {
     typeLabel = 'wetboek';
   } else if (/gecoordineerde wetten/i.test(type)) {
     typeLabel = 'gecoördineerde wetten';
+  } else if (/gecoördineerde wetten/i.test(type)) {
+    typeLabel = 'gecoördineerde wetten';
+  } else if (/grondwetswijziging/i.test(type)) {
+    typeLabel = 'grondwetswijziging';
   } else if (/grondwet/i.test(type)) {
     typeLabel = 'grondwet';
   } else if (/\w+wet/i.test(type)) {


### PR DESCRIPTION
In this PR, the RegEx for finding triggers for this plugins and the processing has been simplified. For some types with a composed name (e.g. kieswet, bosdecreet, ...) the type itself is now included in the search terms before the rest of the search terms while still selecting the correct category, but falls back to a search with only the searh terms when the type is not a composed name.

**To check:**

- the RegEx does not cause issues with surrounding text, and does not override anything the use still wants to keep;
- the plugin triggers on all desired types;
- the typed words in the match appear in the search field.

**Known issues:**

- Immediately inserting a reference after typing will cause an error ("this.parent is null") and not do anything. This has been like this for a while. Reported as GN-3518.