### PR TITLE
Increase date range in AuDatePickers

### DIFF
--- a/addon/components/editor-plugins/citations/search-modal.hbs
+++ b/addon/components/editor-plugins/citations/search-modal.hbs
@@ -56,6 +56,8 @@
                 @alignment="top"
                 @onChange={{this.updateDocumentDateFrom}}
                 @value={{this.documentDateFrom}}
+                @min={{this.minDate}}
+                @max={{this.maxDate}}
                 @localization={{this.datePickerLocalization}} />
             </AuFormRow>
             {{! To }}
@@ -67,6 +69,8 @@
                 @alignment="top"
                 @onChange={{this.updateDocumentDateTo}}
                 @value={{this.documentDateTo}}
+                @min={{this.minDate}}
+                @max={{this.maxDate}}
                 @localization={{this.datePickerLocalization}} />
             </AuFormRow>
 
@@ -81,6 +85,8 @@
                 @alignment="top"
                 @onChange={{this.updatePublicationDateFrom}}
                 @value={{this.publicationDateFrom}}
+                @min={{this.minDate}}
+                @max={{this.maxDate}}
                 @localization={{this.datePickerLocalization}} />
             </AuFormRow>
             {{! To }}
@@ -92,6 +98,8 @@
                 @alignment="top"
                 @onChange={{this.updatePublicationDateTo}}
                 @value={{this.publicationDateTo}}
+                @min={{this.minDate}}
+                @max={{this.maxDate}}
                 @localization={{this.datePickerLocalization}} />
             </AuFormRow>
           </div>

--- a/addon/components/editor-plugins/citations/search-modal.js
+++ b/addon/components/editor-plugins/citations/search-modal.js
@@ -42,6 +42,8 @@ export default class EditorPluginsCitationsSearchModalComponent extends Componen
   @tracked documentDateTo = null;
   @tracked publicationDateFrom = null;
   @tracked publicationDateTo = null;
+  minDate = new Date('1930-01-01T12:00:00');
+  maxDate = new Date(`${new Date().getFullYear() + 10}-01-01T12:00:00`);
 
   get datePickerLocalization() {
     return {


### PR DESCRIPTION
The range of the AuDatePickers is now from 1930 to ten years in the future, because the earliest legislation I could find was from the beginning of the '30.